### PR TITLE
API updates

### DIFF
--- a/pdtf-api-1.2.0.yaml
+++ b/pdtf-api-1.2.0.yaml
@@ -53,6 +53,7 @@ paths:
               schema:
                 type: object
                 description: List of minified transaction objects containing 'transactionId, uprn and status, createdAt, updatedAt'
+                $ref: https://raw.githubusercontent.com/Property-Data-Trust-Framework/schemas/master/src/schemas/pdtf-transaction-search-results.json
       operationId: getTransactions
   /transactions/{id}:
     get:

--- a/pdtf-api-1.2.0.yaml
+++ b/pdtf-api-1.2.0.yaml
@@ -37,12 +37,7 @@ paths:
         "401":
           description: Unauthorized
       description: Create a transaction
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: https://raw.githubusercontent.com/Property-Data-Trust-Framework/schemas/master/src/schemas/pdtf-verified-claims.json
+  /transactions/search:
     get:
       parameters:
         - $ref: "#/components/parameters/uprn"
@@ -56,8 +51,8 @@ paths:
           content:
             application/json:
               schema:
-                type: string
-                description: List of transactionIds and transaction status
+                type: object
+                description: List of minified transaction objects containing 'transactionId, uprn and status, createdAt, updatedAt'
       operationId: getTransactions
   /transactions/{id}:
     get:


### PR DESCRIPTION
* Update `GET /transactions` to `GET /transactions/search`
  * Updated return description
  * @edmolyneux Could you add a schema in the schemas repo for a mini transaction object containing `transactionId, uprn and status, createdAt, updatedAt` ? I can then reference that schema in this spec
* Remove body of `POST transactions` 


Work ref: https://docs.google.com/document/d/1avimLia2AFV8m558XPrUW4LebhYB7B1gaMzpK8tOkbk