### PR TITLE
Update pdtf-api-1.2.0.yaml

### DIFF
--- a/pdtf-api-1.2.0.yaml
+++ b/pdtf-api-1.2.0.yaml
@@ -53,7 +53,7 @@ paths:
               schema:
                 type: object
                 description: List of minified transaction objects containing 'transactionId, uprn and status, createdAt, updatedAt'
-                $ref: https://raw.githubusercontent.com/Property-Data-Trust-Framework/schemas/master/src/schemas/pdtf-transaction-search-results.json
+                $ref: https://raw.githubusercontent.com/Property-Data-Trust-Framework/schemas/master/src/schemas/v1/pdtf-transaction-search-results.json
       operationId: getTransactions
   /transactions/{id}:
     get:
@@ -89,7 +89,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/Property-Data-Trust-Framework/schemas/master/src/schemas/pdtf-verified-claims.json
+                $ref: https://trust.propdata.org.uk/schemas/verifiedClaims/pdtf-verified-claims.json
         "404":
           description: No claims are available for this property
       description: Get a list of claims for a given transaction ID
@@ -106,7 +106,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/Property-Data-Trust-Framework/schemas/master/src/schemas/pdtf-verified-claims.json
+                $ref: https://trust.propdata.org.uk/schemas/verifiedClaims/pdtf-verified-claims.json
         "404":
           description: No verified claims are available for this property
       description: Get a list of claims for a given transaction ID
@@ -145,7 +145,7 @@ paths:
                 content:
                   application/json:
                     schema:
-                      $ref: https://raw.githubusercontent.com/Property-Data-Trust-Framework/schemas/master/src/schemas/pdtf-verified-claims.json
+                      $ref: https://trust.propdata.org.uk/schemas/verifiedClaims/pdtf-verified-claims.json
               responses:
                 "200":
                   description: Please send a 200 response to acknowledge the callback and prevent retries
@@ -188,7 +188,7 @@ components:
       properties:
         $schema: 
           type: "string"
-          example: "https://homebuyingandsellinggroup.co.uk/schemas/pdtf-transaction.json"
+          example: "https://trust.propdata.org.uk/schemas/v3/pdtf-transaction.json"
         transactionId:
           title: "UUID for the transaction"
           type: "string"


### PR DESCRIPTION
Existing schema refs are broken, updated to the latest values.

The ID URL of `pdtf-transaction-search-results.json` is incorrect in the schemas repo, so setting it to the raw.github link for now.